### PR TITLE
Less State Holding in Services

### DIFF
--- a/org.knime.knip.scijava.commands.testing/src/org/knime/knip/scijava/commands/testing/KnimeProcessorTest.java
+++ b/org.knime.knip.scijava.commands.testing/src/org/knime/knip/scijava/commands/testing/KnimeProcessorTest.java
@@ -26,8 +26,8 @@ import org.knime.core.data.def.IntCell;
 import org.knime.core.data.def.LongCell;
 import org.knime.core.data.def.StringCell;
 import org.knime.knip.scijava.commands.DefaultKnimePostprocessor;
-import org.knime.knip.scijava.commands.KnimeInputDataTableService;
-import org.knime.knip.scijava.commands.KnimeOutputDataTableService;
+import org.knime.knip.scijava.commands.KNIMEInputDataTableService;
+import org.knime.knip.scijava.commands.KNIMEOutputDataTableService;
 import org.knime.knip.scijava.commands.adapter.InputAdapterService;
 import org.knime.knip.scijava.commands.adapter.OutputAdapterService;
 import org.knime.knip.scijava.commands.mapping.ColumnInputMappingKnimePreprocessor;
@@ -57,14 +57,14 @@ public class KnimeProcessorTest {
 	@Parameter
 	CommandService m_commandService;
 	@Parameter
-	KnimeInputDataTableService m_inputTableService;
+	KNIMEInputDataTableService m_inputTableService;
 	@Parameter
-	KnimeOutputDataTableService m_outputTableService;
+	KNIMEOutputDataTableService m_outputTableService;
 	@Parameter
 	ColumnModuleItemMappingService m_cimService;
 
 	protected static List<Class<? extends Service>> requiredServices = Arrays.<Class<? extends Service>> asList(
-			KnimeInputDataTableService.class, KnimeOutputDataTableService.class, CommandService.class,
+			KNIMEInputDataTableService.class, KNIMEOutputDataTableService.class, CommandService.class,
 			ColumnModuleItemMappingService.class, InputAdapterService.class, OutputAdapterService.class);
 
 	private static final DataTableSpec m_spec;

--- a/org.knime.knip.scijava.commands/META-INF/MANIFEST.MF
+++ b/org.knime.knip.scijava.commands/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Export-Package: org.knime.knip.scijava.commands,
  org.knime.knip.scijava.commands.settings.types,
  org.knime.knip.scijava.commands.widget,
  org.knime.knip.scijava.commands.widget.impl
+Import-Package: org.slf4j

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultInputDataRowService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultInputDataRowService.java
@@ -1,5 +1,7 @@
 package org.knime.knip.scijava.commands;
 
+import java.lang.ref.WeakReference;
+
 import org.knime.core.data.DataRow;
 import org.knime.core.data.DataTableSpec;
 import org.scijava.Priority;
@@ -7,46 +9,48 @@ import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 
 /**
- * Default implementation of InputDataRowService.
+ * Default implementation of InputDataRowService. Holds a {@link DataRow} and a
+ * {@link DataTableSpec} via a {@link WeakReference} to ensure that they can be
+ * garbage collected once they are not referenced outside this Service.
  * 
  * @author Jonathan Hale (University of Konstanz)
- * 
  */
 @Plugin(type = InputDataRowService.class, priority = DefaultInputDataRowService.PRIORITY)
-public class DefaultInputDataRowService extends AbstractService implements
-		InputDataRowService {
-	
+public class DefaultInputDataRowService extends AbstractService
+		implements InputDataRowService {
+
 	/**
 	 * Priority of this {@link Plugin}
 	 */
 	public static final double PRIORITY = Priority.NORMAL_PRIORITY;
 
-	private DataRow m_row = null;
-	private DataTableSpec m_spec = null;
+	private WeakReference<DataRow> m_row = new WeakReference<>(null);
+	private WeakReference<DataTableSpec> m_spec = new WeakReference<>(null);
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public DataRow getInputDataRow() {
-		return m_row;
+		return m_row.get();
 	}
 
 	/**
 	 * Set the contained DataRow;
+	 * 
 	 * @param dataRow
 	 */
-	public void setDataRow(DataRow dataRow) {
-		m_row = dataRow;
+	public void setDataRow(final DataRow dataRow) {
+		m_row = new WeakReference<>(dataRow);
 	}
 
 	@Override
 	public DataTableSpec getInputDataTableSpec() {
-		return m_spec;
+		return m_spec.get();
 	}
-	
-	public void setDataTableSpec(DataTableSpec spec) {
-		m_spec = spec;
+
+	public void setDataTableSpec(final DataTableSpec spec) {
+		m_spec = new WeakReference<>(spec);
 	}
-	
+
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKNIMEScijavaContext.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKNIMEScijavaContext.java
@@ -21,6 +21,7 @@ public class DefaultKNIMEScijavaContext implements KNIMEScijavaContext {
 
 	private Logger m_log = LoggerFactory.getLogger(getClass());
 
+	@Parameter
 	private Context m_context;
 
 	@Parameter
@@ -63,9 +64,8 @@ public class DefaultKNIMEScijavaContext implements KNIMEScijavaContext {
 		if (m_context == context) {
 			m_log.warn(
 					"CODING PROBLEM - Scijava context set mutiple times. Should only be set once.");
+			return;
 		}
-		m_context = context;
-
 		context.inject(this);
 	}
 

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKNIMEScijavaContext.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKNIMEScijavaContext.java
@@ -1,0 +1,117 @@
+package org.knime.knip.scijava.commands;
+
+import org.knime.knip.scijava.commands.adapter.InputAdapterService;
+import org.knime.knip.scijava.commands.adapter.OutputAdapterService;
+import org.knime.knip.scijava.commands.mapping.ColumnToInputMappingService;
+import org.knime.knip.scijava.commands.mapping.OutputToColumnMappingService;
+import org.knime.knip.scijava.commands.settings.NodeSettingsService;
+import org.knime.knip.scijava.commands.settings.SettingsModelTypeService;
+import org.scijava.Context;
+import org.scijava.plugin.Parameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link KNIMEScijavaContext}. Enables convenient
+ * access to the KNIME related services in a Scijava Context.
+ * 
+ * @author Jonathan Hale (University of Konstanz)
+ */
+public class DefaultKNIMEScijavaContext implements KNIMEScijavaContext {
+
+	private Logger m_log = LoggerFactory.getLogger(getClass());
+
+	private Context m_context;
+
+	@Parameter
+	private InputAdapterService inputAdapterService;
+	@Parameter
+	private OutputAdapterService outputAdapterService;
+	@Parameter
+	private KNIMEInputDataTableService inputTableService;
+	@Parameter
+	private KNIMEOutputDataTableService outputTableService;
+	@Parameter
+	private ColumnToInputMappingService inputMappingService;
+	@Parameter
+	private OutputToColumnMappingService outputMappingService;
+	@Parameter
+	private SettingsModelTypeService settingsModelTypesService;
+	@Parameter
+	private NodeSettingsService nodeSettingsService;
+	@Parameter
+	private KNIMEExecutionService executionService;
+
+	@Override
+	public Context context() {
+		return m_context;
+	}
+
+	@Override
+	public Context getContext() {
+		return context();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @throws IllegalArgumentException
+	 *             If a service is missing
+	 */
+	@Override
+	public void setContext(Context context) throws IllegalArgumentException {
+		if (m_context == context) {
+			m_log.warn(
+					"CODING PROBLEM - Scijava context set mutiple times. Should only be set once.");
+		}
+		m_context = context;
+
+		context.inject(this);
+	}
+
+	@Override
+	public InputAdapterService inputAdapters() {
+		return inputAdapterService;
+	}
+
+	@Override
+	public OutputAdapterService outputAdapters() {
+		return outputAdapterService;
+	}
+
+	@Override
+	public KNIMEInputDataTableService inputTable() {
+		return inputTableService;
+	}
+
+	@Override
+	public KNIMEOutputDataTableService outputTable() {
+		return outputTableService;
+	}
+
+	@Override
+	public ColumnToInputMappingService inputMapping() {
+		return inputMappingService;
+	}
+
+	@Override
+	public OutputToColumnMappingService outputMapping() {
+		return outputMappingService;
+	}
+
+	@Override
+	public SettingsModelTypeService settingsModelTypes() {
+		return settingsModelTypesService;
+	}
+
+	@Override
+	public NodeSettingsService nodeSettings() {
+		return nodeSettingsService;
+	}
+
+	@Override
+	public KNIMEExecutionService execution() {
+		return executionService;
+	}
+
+}

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
@@ -11,9 +11,9 @@ import org.scijava.service.AbstractService;
  * @author Jonathan Hale (University of Konstanz)
  * 
  */
-@Plugin(type = KnimeExecutionService.class, priority = DefaultKnimeExecutionService.PRIORITY)
+@Plugin(type = KNIMEExecutionService.class, priority = DefaultKnimeExecutionService.PRIORITY)
 public class DefaultKnimeExecutionService extends AbstractService implements
-		KnimeExecutionService {
+		KNIMEExecutionService {
 
 	/**
 	 * Priority of this {@link Plugin}

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
@@ -1,34 +1,46 @@
 package org.knime.knip.scijava.commands;
 
+import java.lang.ref.WeakReference;
+
 import org.knime.core.node.ExecutionContext;
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 
 /**
- * Default implementation of KnimeExecutionService.
+ * Default implementation of KnimeExecutionService. Holds a KNIME Node
+ * {@link ExecutionContext} in a {@link WeakReference}, which ensures that the
+ * {@link ExecutionContext} can be garbage collected when execution of a Node
+ * terminates.
  * 
  * @author Jonathan Hale (University of Konstanz)
- * 
+ * @see ExecutionContext
  */
 @Plugin(type = KNIMEExecutionService.class, priority = DefaultKnimeExecutionService.PRIORITY)
-public class DefaultKnimeExecutionService extends AbstractService implements
-		KNIMEExecutionService {
+public class DefaultKnimeExecutionService extends AbstractService
+		implements KNIMEExecutionService {
 
 	/**
 	 * Priority of this {@link Plugin}
 	 */
 	public static final double PRIORITY = Priority.NORMAL_PRIORITY;
 
-	private ExecutionContext m_exec = null;
+	private WeakReference<ExecutionContext> m_exec = new WeakReference<>(null);
 
-	public void setExecutionContex(ExecutionContext e) {
-		m_exec = e;
+	/**
+	 * Set the {@link ExecutionContext}. Note that this service holds the
+	 * {@link ExecutionContext} in a {@link WeakReference}, which means that the
+	 * reference needs to be kept valid outside the service.
+	 * 
+	 * @param e
+	 */
+	public void setExecutionContex(final ExecutionContext e) {
+		m_exec = new WeakReference<>(e);
 	}
-	
+
 	@Override
 	public ExecutionContext getExecutionContext() {
-		return m_exec;
+		return m_exec.get();
 	}
 
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultKnimeExecutionService.java
@@ -32,10 +32,11 @@ public class DefaultKnimeExecutionService extends AbstractService
 	 * {@link ExecutionContext} in a {@link WeakReference}, which means that the
 	 * reference needs to be kept valid outside the service.
 	 * 
-	 * @param e
+	 * @param context
 	 */
-	public void setExecutionContex(final ExecutionContext e) {
-		m_exec = new WeakReference<>(e);
+	@Override
+	public void setExecutionContext(final ExecutionContext context) {
+		m_exec = new WeakReference<>(context);
 	}
 
 	@Override

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultOutputDataRowService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/DefaultOutputDataRowService.java
@@ -1,41 +1,45 @@
 package org.knime.knip.scijava.commands;
 
+import java.lang.ref.WeakReference;
+
 import org.knime.core.data.DataRow;
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 
 /**
- * Default implementation of OutputDataRowService.
+ * Default implementation of OutputDataRowService. Holds a {@link WeakReference}
+ * to a {@link DataRow} to ensure that it can be garbage collected once the
+ * {@link DataRow} is not referenced outside of this service.
  * 
  * @author Jonathan Hale (University of Konstanz)
  * 
  */
 @Plugin(type = OutputDataRowService.class, priority = DefaultOutputDataRowService.PRIORITY)
-public class DefaultOutputDataRowService extends AbstractService implements
-		OutputDataRowService {
+public class DefaultOutputDataRowService extends AbstractService
+		implements OutputDataRowService {
 
 	/**
 	 * Priority of this {@link Plugin}
 	 */
 	public static final double PRIORITY = Priority.NORMAL_PRIORITY;
 
-	private DataRow m_row = null;
+	private WeakReference<DataRow> m_row = new WeakReference<>(null);
 
 	/**
-	 *{@inheritDoc}
+	 * {@inheritDoc}
 	 */
 	@Override
 	public void setOutputDataRow(DataRow r) {
-		m_row = r;
+		m_row = new WeakReference<>(r);
 	}
 
 	/**
-	 *{@inheritDoc}
+	 * {@inheritDoc}
 	 */
 	@Override
 	public DataRow getOutputDataRow() {
-		return m_row;
+		return m_row.get();
 	}
 
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
@@ -24,4 +24,9 @@ public interface KNIMEExecutionService extends Service {
 	 */
 	ExecutionContext getExecutionContext();
 
+	/**
+	 * Set the ExecutionContext for this service to hold.
+	 */
+	void setExecutionContext(ExecutionContext context);
+
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
@@ -18,6 +18,10 @@ import org.scijava.service.Service;
  */
 public interface KNIMEExecutionService extends Service {
 
+	/**
+	 * @return the ExecutionContext held by this service, or null if there is
+	 *         none.
+	 */
 	ExecutionContext getExecutionContext();
 
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEExecutionService.java
@@ -10,13 +10,13 @@ import org.scijava.service.Service;
  * <p>
  * KnimeExecutionService plugins discoverable at runtime must implement this
  * interface and be annotated with @{@link Plugin} with attribute
- * {@link Plugin#type()} = {@link KnimeExecutionService}.class.
+ * {@link Plugin#type()} = {@link KNIMEExecutionService}.class.
  * </p>
  * 
  * @author Jonathan Hale (University of Konstanz)
  * 
  */
-public interface KnimeExecutionService extends Service {
+public interface KNIMEExecutionService extends Service {
 
 	ExecutionContext getExecutionContext();
 

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEInputDataTableService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEInputDataTableService.java
@@ -23,7 +23,7 @@ import org.scijava.service.AbstractService;
  * @author Jonathan Hale (University of Konstanz)
  * 
  */
-public class KnimeInputDataTableService extends AbstractService
+public class KNIMEInputDataTableService extends AbstractService
 		implements InputDataRowService, Iterator<DataRow> {
 
 	private DataTableSpec m_tableSpec;

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEOutputDataTableService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEOutputDataTableService.java
@@ -14,7 +14,7 @@ import org.scijava.service.AbstractService;
  * @author Jonathan Hale (University of Konstanz)
  * 
  */
-public class KnimeOutputDataTableService extends AbstractService implements
+public class KNIMEOutputDataTableService extends AbstractService implements
 		OutputDataRowService {
 
 	private DataContainer m_dataContainer;

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEOutputDataTableService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEOutputDataTableService.java
@@ -1,5 +1,7 @@
 package org.knime.knip.scijava.commands;
 
+import java.lang.ref.WeakReference;
+
 import org.knime.core.data.DataRow;
 import org.knime.core.data.container.DataContainer;
 import org.scijava.service.AbstractService;
@@ -17,8 +19,8 @@ import org.scijava.service.AbstractService;
 public class KNIMEOutputDataTableService extends AbstractService implements
 		OutputDataRowService {
 
-	private DataContainer m_dataContainer;
-	private DataRow m_curRow = null;
+	private WeakReference<DataContainer> m_dataContainer = new WeakReference<>(null);
+	private WeakReference<DataRow> m_curRow = new WeakReference<>(null);
 
 	/**
 	 * Create a KnimeOutputDataTableService with given output DataTableSpec.
@@ -27,23 +29,17 @@ public class KNIMEOutputDataTableService extends AbstractService implements
 	 *            DataTableSpec of the output table.
 	 */
 	public void setOutputContainer(DataContainer container) {
-		m_dataContainer = container;
+		m_dataContainer = new WeakReference<>(container);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public void setOutputDataRow(DataRow r) {
-		m_curRow = r;
+		m_curRow = new WeakReference<>(r);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public DataRow getOutputDataRow() {
-		return m_curRow;
+		return m_curRow.get();
 	}
 
 	/**
@@ -51,17 +47,17 @@ public class KNIMEOutputDataTableService extends AbstractService implements
 	 * sets the current row to null.
 	 */
 	public void appendRow() {
-		if (m_dataContainer != null) {
-			m_dataContainer.addRowToTable(m_curRow);
+		if (m_dataContainer.get() != null) {
+			m_dataContainer.get().addRowToTable(m_curRow.get());
 		}
-		m_curRow = null;
+		m_curRow = new WeakReference<>(null);
 	}
 	
 	/**
 	 * @return the DataContainer set in the Constructor.
 	 */
 	public DataContainer getDataContainer() {
-		return m_dataContainer;
+		return m_dataContainer.get();
 	}
 
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEScijavaContext.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KNIMEScijavaContext.java
@@ -1,0 +1,64 @@
+package org.knime.knip.scijava.commands;
+
+import org.knime.knip.scijava.commands.adapter.InputAdapterService;
+import org.knime.knip.scijava.commands.adapter.OutputAdapterService;
+import org.knime.knip.scijava.commands.mapping.ColumnToInputMappingService;
+import org.knime.knip.scijava.commands.mapping.OutputToColumnMappingService;
+import org.knime.knip.scijava.commands.settings.NodeSettingsService;
+import org.knime.knip.scijava.commands.settings.SettingsModelTypeService;
+import org.scijava.Context;
+import org.scijava.Contextual;
+
+/**
+ * Holds all contextual data of a KNIME Node.
+ * 
+ * @author Jonathan Hale
+ */
+public interface KNIMEScijavaContext extends Contextual {
+
+	/**
+	 * @return the {@link InputAdapterService} in this {@link Context}
+	 */
+	public InputAdapterService inputAdapters();
+
+	/**
+	 * @return the {@link OutputAdapterService} in this {@link Context}
+	 */
+	public OutputAdapterService outputAdapters();
+
+	/**
+	 * @return the {@link KNIMEInputDataTableService} in this {@link Context}
+	 */
+	public KNIMEInputDataTableService inputTable();
+
+	/**
+	 * @return the {@link KNIMEOutputDataTableService} in this {@link Context}
+	 */
+	public KNIMEOutputDataTableService outputTable();
+
+	/**
+	 * @return the {@link ColumnToInputMappingService} in this {@link Context}
+	 */
+	public ColumnToInputMappingService inputMapping();
+
+	/**
+	 * @return the {@link OutputToColumnMappingService} in this {@link Context}
+	 */
+	public OutputToColumnMappingService outputMapping();
+
+	/**
+	 * @return the {@link SettingsModelTypeService} in this {@link Context}
+	 */
+	public SettingsModelTypeService settingsModelTypes();
+
+	/**
+	 * @return the {@link NodeSettingsService} in this {@link Context}
+	 */
+	public NodeSettingsService nodeSettings();
+
+	/**
+	 * @return the {@link KNIMEExecutionService} in this {@link Context}
+	 */
+	public KNIMEExecutionService execution();
+
+}

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KnimePreprocessor.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/KnimePreprocessor.java
@@ -6,7 +6,7 @@ import org.scijava.plugin.Plugin;
 
 /**
  * A preprocessor that handles unresolved parameters of various types using a
- * {@link KnimeInputDataTableService}.
+ * {@link KNIMEInputDataTableService}.
  * <p>
  * KnimePreprocessor plugins discoverable at runtime must implement this
  * interface and be annotated with @{@link Plugin} with attribute

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/mapping/ColumnInputMappingKnimePreprocessor.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/mapping/ColumnInputMappingKnimePreprocessor.java
@@ -4,7 +4,7 @@ import org.knime.core.data.DataCell;
 import org.knime.core.data.DataRow;
 import org.knime.core.data.DataTable;
 import org.knime.core.data.DataTableSpec;
-import org.knime.knip.scijava.commands.KnimeInputDataTableService;
+import org.knime.knip.scijava.commands.KNIMEInputDataTableService;
 import org.knime.knip.scijava.commands.KnimePreprocessor;
 import org.knime.knip.scijava.commands.adapter.InputAdapter;
 import org.knime.knip.scijava.commands.adapter.InputAdapterService;
@@ -32,7 +32,7 @@ public class ColumnInputMappingKnimePreprocessor
 	ColumnToInputMappingService m_cimService;
 
 	@Parameter
-	KnimeInputDataTableService m_inputTable;
+	KNIMEInputDataTableService m_inputTable;
 
 	@Parameter
 	InputAdapterService m_inputAdapters;

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultNodeSettingsService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultNodeSettingsService.java
@@ -25,7 +25,8 @@ import org.scijava.service.AbstractService;
 public class DefaultNodeSettingsService extends AbstractService
 		implements NodeSettingsService {
 
-	private WeakReference<Map<String, SettingsModel>> m_settingsModels;
+	private WeakReference<Map<String, SettingsModel>> m_settingsModels = new WeakReference<Map<String, SettingsModel>>(
+			null);
 
 	@Parameter
 	SettingsModelTypeService m_typeService;

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultNodeSettingsService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultNodeSettingsService.java
@@ -1,8 +1,9 @@
 package org.knime.knip.scijava.commands.settings;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 import org.knime.core.node.InvalidSettingsException;
@@ -17,109 +18,163 @@ import org.scijava.service.AbstractService;
 /**
  * Default implementation of NodeSettingsService.
  * 
- * @author Jonathan Hale
+ * @author Jonathan Hale (University of Konstanz)
  */
 @SuppressWarnings("rawtypes")
 @Plugin(type = NodeSettingsService.class)
-public class DefaultNodeSettingsService extends AbstractService implements
-		NodeSettingsService {
+public class DefaultNodeSettingsService extends AbstractService
+		implements NodeSettingsService {
 
-	final Map<String, SettingsModel> m_settingsModels = new HashMap<String, SettingsModel>();
+	private WeakReference<Map<String, SettingsModel>> m_settingsModels;
 
 	@Parameter
 	SettingsModelTypeService m_typeService;
 
+	@Override
+	public void setSettingsModels(
+			final Map<String, SettingsModel> settingsModels) {
+		m_settingsModels = new WeakReference<Map<String, SettingsModel>>(
+				settingsModels);
+	}
+
+	/*
+	 * @return Map referenced by m_settingsModels or empty Map. Never
+	 * <code>null</code>
+	 */
+	private Map<String, SettingsModel> getSafeSettingsModelsMap() {
+		if (m_settingsModels.get() == null) {
+			return Collections.emptyMap();
+		}
+
+		return m_settingsModels.get();
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public void setValue(final ModuleItem<?> moduleItem, final Object value) {
-		final SettingsModel sm = m_settingsModels.get(moduleItem.getName());
+		final SettingsModel sm = getSafeSettingsModelsMap()
+				.get(moduleItem.getName());
+		if (sm == null) {
+			return;
+		}
 
 		final SettingsModelType t = m_typeService.getSettingsModelTypeFor(sm);
-		
+
 		t.setValue(sm, value);
 	}
 
 	@Override
 	public Object getValue(final ModuleItem<?> moduleItem) {
-		final SettingsModel sm = m_settingsModels.get(moduleItem.getName());
+		final SettingsModel sm = getSafeSettingsModelsMap()
+				.get(moduleItem.getName());
+		if (sm == null) {
+			return null;
+		}
 
 		final SettingsModelType t = m_typeService.getSettingsModelTypeFor(sm);
-
 		if (t != null) {
 			return t.getValue(sm);
 		}
 
 		return null;
 	}
-	
+
 	@Override
 	public SettingsModel createSettingsModel(final ModuleItem<?> moduleItem) {
-		SettingsModel sm = m_settingsModels.get(moduleItem.getName());
-		
-		if (sm != null) {
-			// already exists, do not overwrite.
-			return sm;
-		}
-		
-		final SettingsModelType t = m_typeService.getSettingsModelTypeFor(moduleItem.getType());
-		
+		SettingsModel sm = getSafeSettingsModelsMap().get(moduleItem.getName());
+
+		final SettingsModelType t = m_typeService
+				.getSettingsModelTypeFor(moduleItem.getType());
 		if (t == null) {
 			return null;
 		}
-		
+
 		sm = t.create(moduleItem.getName(), moduleItem.getMinimumValue());
-		m_settingsModels.put(moduleItem.getName(), sm);
-		
+
 		return sm;
 	}
-	
+
 	@Override
 	public Collection<SettingsModel> createSettingsModels(
 			final Iterable<ModuleItem<?>> moduleItems) {
 		final ArrayList<SettingsModel> settingsModels = new ArrayList<SettingsModel>();
-		
+
 		for (final ModuleItem i : moduleItems) {
-			SettingsModel sm = createSettingsModel(i);
-			
-			if (sm != null) {
-				settingsModels.add(sm);
-			}
+			final SettingsModel sm = createSettingsModel(i);
+			settingsModels.add(sm);
 		}
 		return settingsModels;
 	}
 
 	@Override
-	public Collection<SettingsModel> getSettingsModels() {
-		return m_settingsModels.values();
-	}
-
-	@Override
 	public boolean validateSettings(final NodeSettingsRO settings)
 			throws InvalidSettingsException {
-		for (final SettingsModel sm : m_settingsModels.values()) {
+		for (final SettingsModel sm : getSafeSettingsModelsMap().values()) {
 			sm.validateSettings(settings);
 		}
-		
+
 		return true;
 	}
 
 	@Override
 	public boolean loadSettingsFrom(final NodeSettingsRO settings)
 			throws InvalidSettingsException {
-		for (final SettingsModel sm : m_settingsModels.values()) {
+		for (final SettingsModel sm : getSafeSettingsModelsMap().values()) {
 			sm.loadSettingsFrom(settings);
 		}
-		
+
 		return true;
 	}
 
 	@Override
 	public boolean saveSettingsTo(final NodeSettingsWO settings) {
-		for (final SettingsModel sm : m_settingsModels.values()) {
+		for (final SettingsModel sm : getSafeSettingsModelsMap().values()) {
 			sm.saveSettingsTo(settings);
 		}
-		
 		return true;
+
+	}
+
+	@Override
+	public Map<String, SettingsModel> getSettingsModels() {
+		return m_settingsModels.get();
+	}
+
+	@Override
+	public SettingsModel createAndAddSettingsModel(
+			final ModuleItem<?> moduleItem) {
+		SettingsModel sm = getSafeSettingsModelsMap().get(moduleItem.getName());
+		if (sm != null) {
+			// already exists, do not overwrite.
+			return sm;
+		}
+
+		sm = createSettingsModel(moduleItem);
+		addSettingsModel(moduleItem.getName(), sm);
+		return sm;
+	}
+
+	private void addSettingsModel(final String name, final SettingsModel sm) {
+		if (m_settingsModels.get() != null) {
+			m_settingsModels.get().put(name, sm);
+		}
+	}
+
+	@Override
+	public Collection<SettingsModel> createAndAddSettingsModels(
+			final Iterable<ModuleItem<?>> moduleItems) {
+		if (m_settingsModels.get() == null) {
+			return createSettingsModels(moduleItems);
+		}
+
+		final ArrayList<SettingsModel> settingsModels = new ArrayList<SettingsModel>();
+
+		for (final ModuleItem i : moduleItems) {
+			final SettingsModel sm = createAndAddSettingsModel(i);
+			m_settingsModels.get().put(i.getName(), sm);
+		}
+
+		return settingsModels;
 	}
 
 }

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultSettingsModelTypeService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/DefaultSettingsModelTypeService.java
@@ -8,16 +8,16 @@ import org.scijava.plugin.Plugin;
  * Straight forward, rather ineffective default implementation of
  * SettingsModelTypeService.
  *
- * Ineffective because {@link #getSettingsModelTypeFor(SettingsModel)}
- * uses linear search to find a matching SettingsModelType.
+ * Ineffective because {@link #getSettingsModelTypeFor(SettingsModel)} uses
+ * linear search to find a matching SettingsModelType.
  * 
  * @author Jonathan Hale (University of Konstanz)
  */
 @SuppressWarnings("rawtypes")
 @Plugin(type = SettingsModelTypeService.class)
-public class DefaultSettingsModelTypeService extends
-		AbstractSingletonService<SettingsModelTypePlugin> implements
-		SettingsModelTypeService {
+public class DefaultSettingsModelTypeService
+		extends AbstractSingletonService<SettingsModelTypePlugin>
+		implements SettingsModelTypeService {
 
 	@Override
 	public Class<SettingsModelTypePlugin> getPluginType() {
@@ -25,7 +25,12 @@ public class DefaultSettingsModelTypeService extends
 	}
 
 	@Override
-	public SettingsModelType getSettingsModelTypeFor(SettingsModel settingsModel) {
+	public SettingsModelType getSettingsModelTypeFor(
+			SettingsModel settingsModel) {
+		if (settingsModel == null) {
+			return null;
+		}
+
 		for (SettingsModelTypePlugin p : getInstances()) {
 			if (p.getSettingsModelClass().isInstance(settingsModel)) {
 				return p;
@@ -43,7 +48,7 @@ public class DefaultSettingsModelTypeService extends
 				return p;
 			}
 		}
-		
+
 		return null;
 	}
 

--- a/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/SettingsModelTypeService.java
+++ b/org.knime.knip.scijava.commands/src/org/knime/knip/scijava/commands/settings/SettingsModelTypeService.java
@@ -16,8 +16,8 @@ import org.scijava.plugin.SingletonService;
  * @author Jonathan Hale (University of Konstanz)
  */
 @SuppressWarnings("rawtypes")
-public interface SettingsModelTypeService extends
-		SingletonService<SettingsModelTypePlugin> {
+public interface SettingsModelTypeService
+		extends SingletonService<SettingsModelTypePlugin> {
 
 	/**
 	 * Get a SettingModelType which can set and get values from the specified
@@ -26,15 +26,18 @@ public interface SettingsModelTypeService extends
 	 * @param settingsModel
 	 *            SettingsModel to find a SettingsModelType for.
 	 * @return a SettingsModelType which can set/get values from settingsModel
-	 *         or null if none could be found.
+	 *         or null if none could be found or <code>settingsModel</code> was
+	 *         <code>null</code>.
 	 */
 	SettingsModelType getSettingsModelTypeFor(SettingsModel settingsModel);
 
 	/**
 	 * Get a SettingsModel type which can assign value to a SettingsModel.
-	 * @param value the value which to store in a SettingsModel.
+	 * 
+	 * @param value
+	 *            the value which to store in a SettingsModel.
 	 * @return SettingsModelType which stores values of given value type.
 	 */
 	SettingsModelType getSettingsModelTypeFor(Class<?> value);
-	
+
 }


### PR DESCRIPTION
Hi @dietzc !

Here is a first pullrequest for less states. Reasoning behind everthing:
- There is **not** only one context which keeps state of everything, because you may only want to have one or the other state for testing (output table service for example, but no node ExecutionContext).
- **Instead** there is a `KNIMEScijavaContext` which is inspired by `OpService` in that it has getter methods to access all KNIME related services and therefore **acts as** this "central service holding masterclass".
- The state is now held **outside of all services**, with `WeakReferences` to them inside the service itself. This ensures that all the state information can be garbage collected with the NodeModel and NodeDialog.
- Why are the services not completely stateless? - This allows us to **pass the states** to the pre- and postpostprocessors.

I hope you are fairly content with the solution I came up with. Further work can be done later, but finishing the ScriptingNode has greater priority.

Greetings,
Jonathan
