### PR TITLE
Make PluginIndex reusable

### DIFF
--- a/org.knime.knip.scijava.core/META-INF/MANIFEST.MF
+++ b/org.knime.knip.scijava.core/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Export-Package: org.knime.knip.scijava.core
+Export-Package: org.knime.knip.scijava.core,
+ org.knime.knip.scijava.core.pluginindex

--- a/org.knime.knip.scijava.core/src/org/knime/knip/scijava/core/pluginindex/ReusablePluginIndex.java
+++ b/org.knime.knip.scijava.core/src/org/knime/knip/scijava/core/pluginindex/ReusablePluginIndex.java
@@ -1,0 +1,25 @@
+package org.knime.knip.scijava.core.pluginindex;
+
+import org.scijava.plugin.PluginFinder;
+import org.scijava.plugin.PluginIndex;
+
+/**
+ * {@link PluginFinder} which can be reused without re-adding all plugins from a
+ * {@link PluginFinder} to the index when creating a Context with this plugin
+ * index.
+ * 
+ * @author Jonathan Hale (University of Konstanz)
+ */
+public class ReusablePluginIndex extends PluginIndex {
+
+	/* flag to keep track of whether #discover() has been called already */
+	private boolean discovered = false;
+
+	@Override
+	public void discover() {
+		if (!discovered) {
+			super.discover();
+		}
+		discovered = true;
+	}
+}

--- a/org.knime.knip.scijava.core/src/org/knime/knip/scijava/core/pluginindex/ReusablePluginIndex.java
+++ b/org.knime.knip.scijava.core/src/org/knime/knip/scijava/core/pluginindex/ReusablePluginIndex.java
@@ -15,6 +15,21 @@ public class ReusablePluginIndex extends PluginIndex {
 	/* flag to keep track of whether #discover() has been called already */
 	private boolean discovered = false;
 
+	/**
+	 * @see PluginIndex#PluginIndex()
+	 */
+	public ReusablePluginIndex() {
+		super();
+	}
+
+	/**
+	 * @param pluginFinder
+	 * @see PluginIndex#PluginIndex(PluginFinder)
+	 */
+	public ReusablePluginIndex(final PluginFinder pluginFinder) {
+		super(pluginFinder);
+	}
+
 	@Override
 	public void discover() {
 		if (!discovered) {


### PR DESCRIPTION
Hii @dietzc !

I found out that `PluginIndex` re-adds all plugins of the `PluginFinder` everytime a new `Context` is created. This results in duplicates which are explicitly allowed by `PluginIndex`. Also, plugins are re-discovered every Context creation, which eliminates the performance gain we hoped for.

I believe this PR will solve that problem.

Greetings, 
Jonathan
