### PR TITLE
Fix StringIndexOutOfBoundsException issue on class load.

### DIFF
--- a/org.knime.scijava.core/src/org/knime/scijava/core/ResourceAwareClassLoader.java
+++ b/org.knime.scijava.core/src/org/knime/scijava/core/ResourceAwareClassLoader.java
@@ -144,7 +144,13 @@ public class ResourceAwareClassLoader extends ClassLoader {
 							// we want to avoid transitive resolving of
 							// dependencies
 							final String host = resource.getHost();
-							if (bundle.getBundleId() == Long.valueOf(host.substring(0, host.indexOf(".")))) {
+							final int dotIndex = host.indexOf('.');
+							// when the resource is not in the osgi modules(e.g., nashorn.jar of jre),
+							// the url doesn't contain '.'. 
+							if (dotIndex <= 0) {
+								continue;
+							}
+							if (bundle.getBundleId() == Long.valueOf(host.substring(0, dotIndex))) {
 								safeAdd(urls.get(res), resource);
 							}
 						}


### PR DESCRIPTION
Added negative index check for String#indexOf(String).

We want to use JavaFX UI in KNIME node extension.
For that, we need to specify '-Dorg.osgi.framework.bundle.parent=ext' in knime.ini,
However, when we specify that, the StringIndexOutOfBoundsException occurs because the url of non-osgi bundle resource doesn't contains bundle id.

Could you merge this simple check?